### PR TITLE
feat: allow multiple connections to the channel server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "channelserver"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/channelserver/Cargo.toml
+++ b/channelserver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "channelserver"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["jr conlin<src+pairsona@jrconlin.com"]
 
 [dependencies]

--- a/channelserver/src/logging.rs
+++ b/channelserver/src/logging.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter, Result};
 
 use actix::prelude::{Actor, Context, Handler};
@@ -63,6 +64,7 @@ impl Actor for MozLogger {
 pub struct LogMessage {
     pub level: ErrorLevel,
     pub msg: String,
+    pub attributes: Option<HashMap<String, String>>,
 }
 
 impl Display for LogMessage {
@@ -74,16 +76,11 @@ impl Display for LogMessage {
             ErrorLevel::Error => "ERROR",
             ErrorLevel::Critical => "CRITICAL",
         };
-        /* TODO: Eventually add attributes
-        let mut attrs = Vec::new();
-        if Some(&self.attributes) {
-            for (k, v) in &self.attributes {
-                attrs.push(format!("{} => {}", k, v));
-            }
+        let mut msg = format!("{}: {}", level, self.msg);
+        if let Some(ref attributes) = self.attributes {
+            msg = format!("{} :: {:?}", msg, attributes);
         }
-        write!(f, "## {}: {} ({})", level, self.msg, attrs.join(", "));
-        */
-        Ok(write!(f, "{}", self.msg)?)
+        Ok(write!(f, "{}", msg)?)
     }
 }
 

--- a/channelserver/src/main.rs
+++ b/channelserver/src/main.rs
@@ -28,7 +28,6 @@ extern crate ipnet;
 extern crate maxminddb;
 extern crate reqwest;
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -56,11 +55,36 @@ fn channel_route(req: &HttpRequest<session::WsChannelSessionState>) -> Result<Ht
     // manually extracting the id from the path.
     let mut path: Vec<_> = req.path().split("/").collect();
     let meta_info = meta::SenderData::from(req.clone());
-    let channel =
-        Uuid::parse_str(path.pop().unwrap_or_else(|| "")).unwrap_or_else(|_| Uuid::new_v4());
+    let mut initial_connect = true;
+    let channel = match path.pop() {
+        Some(id) => {
+            // if the id is valid, but not present, treat it like a "None"
+            if id.len() == 0 {
+                Uuid::new_v4()
+            } else {
+                initial_connect = false;
+                Uuid::parse_str(id).unwrap_or_else(|e| {
+                    &req.state().log.do_send(logging::LogMessage {
+                        level: logging::ErrorLevel::Warn,
+                        msg: format!("Invalid ChannelID specified: {:?}", e),
+                        attributes: meta_info.clone().into(),
+                    });
+                    Uuid::nil()
+                })
+            }
+        }
+        None => Uuid::new_v4(),
+    };
+    if channel == Uuid::nil() {
+        return Ok(HttpResponse::new(http::StatusCode::NOT_FOUND));
+    }
     &req.state().log.do_send(logging::LogMessage {
         level: logging::ErrorLevel::Info,
-        msg: format!("Creating session for channel: \"{}\"", channel.to_simple()),
+        msg: format!(
+            "Creating session for {} channel: \"{}\"",
+            if initial_connect { "new" } else { "candidate" },
+            channel.to_simple().to_string()
+        ),
         attributes: meta_info.clone().into(),
     });
 
@@ -72,6 +96,7 @@ fn channel_route(req: &HttpRequest<session::WsChannelSessionState>) -> Result<Ht
             expiry: Instant::now() + Duration::from_secs(req.state().connection_lifespan),
             channel: channel,
             meta: meta_info,
+            initial_connect,
         },
     )
 }

--- a/channelserver/src/settings.rs
+++ b/channelserver/src/settings.rs
@@ -8,7 +8,7 @@ static PREFIX: &str = "PAIR";
 pub struct Settings {
     pub hostname: String,             // server hostname (localhost)
     pub port: u16,                    // server port (8000)
-    pub max_clients: u8,              // Max clients per channel (2)
+    pub max_channel_connections: u8,  // Max connections per channel (3)
     pub conn_lifespan: u64,           // Total connection lifespan in seconds (300)
     pub client_timeout: u64,          // Client timeout for pong responses (30)
     pub max_exchanges: u8,            // Max number of messages before channel shutdown (3)
@@ -21,6 +21,7 @@ pub struct Settings {
     pub ip_reputation_server: String, // IP Reputation server. Leave blank to disable ("")
     pub iprep_min: u8,                // Minimum IP Reputation (0)
     pub ip_violation: String,         // Name of the abuse violation
+    pub heartbeat: u64,               // Heartbeat rate in seconds for pings (5)
 }
 
 impl Settings {
@@ -32,7 +33,7 @@ impl Settings {
         settings.set_default("max_exchanges", 3)?;
         settings.set_default("conn_lifespan", 300)?;
         settings.set_default("client_timeout", 30)?;
-        settings.set_default("max_clients", 2)?;
+        settings.set_default("max_channel_connections", 3)?;
         settings.set_default("max_data", 0)?;
         settings.set_default("port", 8000)?;
         settings.set_default("hostname", "0.0.0.0".to_owned())?;
@@ -42,6 +43,7 @@ impl Settings {
         settings.set_default("ip_reputation_server", "".to_owned())?;
         settings.set_default("iprep_min", 0)?;
         settings.set_default("ip_violation", "channel_abuse".to_owned())?;
+        settings.set_default("heartbeat", 5)?;
         // Get the run environment
         let env = env::var("RUN_MODE").unwrap_or("development".to_owned());
         // start with any local config file.


### PR DESCRIPTION
* beyond the second connection, check that the remote IP matches one of
  the known IPs.
* Add sender metadata to logging messages (issue #34)
* moved static heartbeat and connection timeouts to settings

Issue #34
Closes #33