### PR TITLE
fix: typo in log about creating session

### DIFF
--- a/channelserver/src/logging.rs
+++ b/channelserver/src/logging.rs
@@ -47,7 +47,8 @@ impl MozLogger {
                 "{}-{}",
                 env!("CARGO_PKG_NAME"),
                 env!("CARGO_PKG_VERSION")
-            )).msg_type(format!("{}:log", env!("CARGO_PKG_NAME")))
+            ))
+            .msg_type(format!("{}:log", env!("CARGO_PKG_NAME")))
             .build()
             .fuse();
         let drain = slog_async::Async::new(json_drain).build().fuse();

--- a/channelserver/src/main.rs
+++ b/channelserver/src/main.rs
@@ -143,7 +143,8 @@ fn cspreport(
             let bstr = str::from_utf8(&body).unwrap();
             warn!(log.log, "CSP Report"; "report"=> bstr);
             Ok(HttpResponse::Ok().into())
-        }).responder()
+        })
+        .responder()
 }
 
 fn build_app(app: App<session::WsChannelSessionState>) -> App<session::WsChannelSessionState> {
@@ -261,7 +262,8 @@ fn main() {
         };
 
         build_app(App::with_state(state))
-    }).bind(&addr)
+    })
+    .bind(&addr)
     .unwrap()
     .start();
 
@@ -313,9 +315,11 @@ mod test {
             .resource("/v1/ws/", |r| r.route().f(channel_route))
             .resource("/__version__", |r| {
                 r.method(http::Method::GET).f(show_version)
-            }).resource("/__heartbeat__", |r| {
+            })
+            .resource("/__heartbeat__", |r| {
                 r.method(http::Method::GET).f(heartbeat)
-            }).resource("/__lbheartbeat__", |r| {
+            })
+            .resource("/__lbheartbeat__", |r| {
                 r.method(http::Method::GET).f(lbheartbeat)
             });
         })

--- a/channelserver/src/main.rs
+++ b/channelserver/src/main.rs
@@ -93,7 +93,7 @@ fn channel_route(req: &HttpRequest<session::WsChannelSessionState>) -> Result<Ht
     info!(
         &req.state().log.log,
         "Creating session for {} channel: \"{}\"",
-        if initial_connect {"new"} else {"candiate"},
+        if initial_connect {"new"} else {"candidate"},
         channel.to_string();
         "remote_ip" => &meta_info.remote
     );

--- a/channelserver/src/meta.rs
+++ b/channelserver/src/meta.rs
@@ -117,7 +117,8 @@ fn get_ua(
                 return "".to_owned();
             }
             Ok(s) => s.to_owned(),
-        }) {
+        })
+    {
         if ua == "".to_owned() {
             // If it's blank, it's None.
             return None;
@@ -173,7 +174,8 @@ fn get_remote(
                             Err(err) => {
                                 return Err(HandlerErrorKind::BadRemoteAddrError(
                                     "Bad IP Specified".to_owned(),
-                                ).into());
+                                )
+                                .into());
                             }
                         }
                     }
@@ -185,12 +187,14 @@ fn get_remote(
                 Err(err) => Err(HandlerErrorKind::BadRemoteAddrError(format!(
                     "Unknown address in X-Forwarded-For: {:?}",
                     err
-                )).into()),
+                ))
+                .into()),
             }
         }
         None => Err(HandlerErrorKind::BadRemoteAddrError(format!(
             "No X-Forwarded-For found for proxied connection"
-        )).into()),
+        ))
+        .into()),
     }
 }
 
@@ -213,7 +217,8 @@ fn get_location(
             .map(|mut r| {
                 let end = r.find(':').unwrap_or(r.len());
                 r.drain(..end).collect()
-            }).unwrap_or(String::from(""));
+            })
+            .unwrap_or(String::from(""));
         if let Ok(loc) = remote.parse() {
             if let Ok(city) = iploc.lookup::<City>(loc).map_err(|err| {
                 handle_city_err(log, &err);

--- a/channelserver/src/server.rs
+++ b/channelserver/src/server.rs
@@ -279,11 +279,11 @@ impl Handler<Connect> for ChannelServer {
             // Is this the first time we're requesting this channel?
             if !&msg.initial_connect {
                 warn!(
-                        self.log.log,
-                        "Attempt to connect to unknown channel";
-                        "channel" => &chan_id.to_string(),
-                        "remote_ip" => &msg.remote.clone().unwrap_or("Unknown".to_owned()),
-                    );
+                    self.log.log,
+                    "Attempt to connect to unknown channel";
+                    "channel" => &chan_id.to_string(),
+                    "remote_ip" => &msg.remote.clone().unwrap_or("Unknown".to_owned()),
+                );
                 return 0;
             }
             entry.insert(HashMap::new());
@@ -324,11 +324,11 @@ impl Handler<Connect> for ChannelServer {
             }
         };
         debug!(self.log.log,
-            "Adding session to channel";
-            "channel" => &chan_id.to_string(),
-            "session" => &new_session.session_id,
-            "remote_ip" => &new_session.remote.clone().unwrap_or("Uknown".to_owned()),
-            );
+        "Adding session to channel";
+        "channel" => &chan_id.to_string(),
+        "session" => &new_session.session_id,
+        "remote_ip" => &new_session.remote.clone().unwrap_or("Uknown".to_owned()),
+        );
         group.insert(session_id.clone(), new_session);
         // tell the client what their channel is.
         let jpath = json!({ "link": format!("/v1/ws/{}", chan_id),
@@ -371,9 +371,11 @@ impl Handler<ClientMessage> for ChannelServer {
                 &json!({
                     "message": &msg.message,
                     "sender": &msg.sender,
-                }).to_string(),
+                })
+                .to_string(),
                 msg.id,
-            ).is_err()
+            )
+            .is_err()
         {
             self.shutdown(&msg.channel)
         }

--- a/channelserver/src/session.rs
+++ b/channelserver/src/session.rs
@@ -66,7 +66,8 @@ impl Actor for WsChannelSession {
                 channel: self.channel.clone(),
                 remote: self.meta.remote.clone(),
                 initial_connect: self.initial_connect,
-            }).into_actor(self)
+            })
+            .into_actor(self)
             .then(|res, act, ctx| {
                 match res {
                     Ok(session_id) => {
@@ -94,7 +95,8 @@ impl Actor for WsChannelSession {
                     }
                 }
                 fut::ok(())
-            }).wait(ctx);
+            })
+            .wait(ctx);
     }
 
     /// Stop Session and alert all others in channel to shut down.


### PR DESCRIPTION
I was reading the logging source code and usage, and saw this word `candiate`. Since none of my dictionaries had it, I assumed it was a typo :) 

(Feel free to close violently if it's not!)