### PR TITLE
chore: update Docker rust to 1.45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Docker 17.05 or higher required for multi-stage builds
-FROM rust:1.42.0-stretch as builder
+FROM rust:1.45-stretch as builder
 ADD . /app
 WORKDIR /app
 # Make sure that this matches in .travis.yml

--- a/channelserver/src/channelid.rs
+++ b/channelserver/src/channelid.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use base64;
 use rand::RngCore;
 use serde::ser::{Serialize, Serializer};
 

--- a/channelserver/src/error.rs
+++ b/channelserver/src/error.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::io;
 
-use cadence;
 use failure::{Backtrace, Context, Fail};
 
 #[derive(Debug)]

--- a/channelserver/src/logging.rs
+++ b/channelserver/src/logging.rs
@@ -6,9 +6,7 @@ use actix::prelude::{Actor, Context};
 
 use slog::slog_o;
 use slog::Drain;
-use slog_async;
 use slog_mozlog_json::MozLogJson;
-use slog_term;
 
 #[derive(Clone, Debug)]
 pub struct MozLogger {


### PR DESCRIPTION
## Description
Update Docker image to use rust 1.45
* fix clippy, fmt changes

## Testing

N/A

## Issue(s)

N/A
