### PR TITLE
chore(timeout): increase timeout for client_timeout

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,7 +36,7 @@ impl Default for Settings {
             port: 8000,
             max_channel_connections: 3,
             conn_lifespan: 300,
-            client_timeout: 30,
+            client_timeout: 60, // FXA-12122
             max_exchanges: 10,
             max_data: 0,
             debug: false,


### PR DESCRIPTION
## Description
Increase client_timeout from 30s to 60s  

## Testing

## Issue(s)
[FXA-12122](https://mozilla-hub.atlassian.net/browse/FXA-12122?focusedCommentId=1109835&sourceType=mention)
